### PR TITLE
Introduce basic MPRIS support

### DIFF
--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -43,6 +43,14 @@ Page {
         }
     }
 
+    function scaleVolumeToPercent(value) {
+        return (0 + (value-0)*(200-0)/(512-0));
+    }
+
+    function setVolume(volume) {
+        sendCommand("volume&val=" + volume)
+    }
+
     function pause() {
         sendCommand("pl_pause")
         iconButtons.playing = false
@@ -579,8 +587,8 @@ Page {
                             minimumValue: 0
                             maximumValue: 512
                             value: 100
-                            valueText: "Volume: " + (0 + (value-0)*(200-0)/(512-0)).toFixed(0)
-                            onValueChanged: sendCommand("volume&val=" + value.toFixed(0))
+                            valueText: "Volume: " + scaleVolumeToPercent(value).toFixed(0)
+                            onValueChanged: page.setVolume(value.toFixed(0))
                         }
                     }
                     Row{
@@ -933,7 +941,14 @@ Page {
         playbackStatus: iconButtons.playing ? Mpris.Playing : Mpris.Stopped
         loopStatus: Mpris.None
         shuffle: false
-        volume: 1
+        volume: slVol.value / 512.0 * 10
+
+        onVolumeRequested: {
+            console.log("Set volume", volume, "requested");
+            volume /= 10.0;
+            page.setVolume((volume * 512.0).toFixed(0));
+            slVol.value = volume * 512.0;
+        }
 
         onPauseRequested: {
             page.pause();

--- a/rpm/harbour-vlc_remote.spec
+++ b/rpm/harbour-vlc_remote.spec
@@ -22,10 +22,12 @@ Source0:    %{name}-%{version}.tar.bz2
 Source100:  harbour-vlc_remote.yaml
 Requires:   qt5-qtdeclarative-import-xmllistmodel
 Requires:   sailfishsilica-qt5 >= 0.10.9
+Requires:   mpris-qt5
 BuildRequires:  pkgconfig(sailfishapp) >= 0.0.10
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Quick)
+BuildRequires:  pkgconfig(mpris-qt5)
 BuildRequires:  desktop-file-utils
 
 %description

--- a/rpm/harbour-vlc_remote.yaml
+++ b/rpm/harbour-vlc_remote.yaml
@@ -17,9 +17,11 @@ PkgConfigBR:
 - Qt5Core
 - Qt5Qml
 - Qt5Quick
+- mpris-qt5
 Requires:
 - qt5-qtdeclarative-import-xmllistmodel
 - sailfishsilica-qt5 >= 0.10.9
+- mpris-qt5
 Files:
 - /usr/share/icons/hicolor/86x86/apps
 - /usr/share/applications


### PR DESCRIPTION
Hello,

I added MPRIS (http://specifications.freedesktop.org/mpris-spec/latest/) support to the player for the purpose of controlling this program via my Pebble (I'm running https://github.com/smokku/pebble/ on my Jolla, which also support MPRIS). The changes are small, as most of the work is done by https://github.com/nemomobile/qtmpris. Largest changes come from consolidating the multiple places to control the player into one place. A more proper solution would be to have a separate component for controlling VLC, but that can be refactored in later.. :)

I guess this may be useful for other cases as well. Not sure if there is any particular MPRIS support in the client side in Jolla though. But at least this OpenRepos package seems relevant: sailfishos-lockscreen-player-patch-0.0.10-1.armv7hl.

The volume thingy is a bit iffy. I just put the 10 there to stop too big sound changes. Maybe the range is 0..100. Doesn't seem to be documented.

I've only tried this on my system ;-), and in particular I'm wondering if it will compile out-of-the box on other systems (I initially manually installed qtpris5 and qtpris5-dev packages on my build environment).

The biggest thing missing is the track list/play list support, but they are still in mpris-qt5's TODO list..